### PR TITLE
Switch from third_party/basilisk submodule to PyPI bsk package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/basilisk"]
-	path = third_party/basilisk
-	url = https://github.com/AVSLab/basilisk.git

--- a/constellation/environments/basilisk/basilisk_satellite.py
+++ b/constellation/environments/basilisk/basilisk_satellite.py
@@ -319,11 +319,12 @@ class BasiliskSatellite:
         )
 
         # mrp_control
-        rw_params_message = self._rw_factory.getConfigMessage()
+        # Store as instance variable to prevent garbage collection (bsk v2.9.0+)
+        self._rw_params_message = self._rw_factory.getConfigMessage()
         self._mrp_control.guidInMsg.subscribeTo(
             self._pointing_guide.attGuidOutMsg,
         )
-        self._mrp_control.rwParamsInMsg.subscribeTo(rw_params_message)
+        self._mrp_control.rwParamsInMsg.subscribeTo(self._rw_params_message)
         self._mrp_control.rwSpeedsInMsg.subscribeTo(
             self._rw_state_effector.rwSpeedOutMsg,
         )
@@ -332,7 +333,7 @@ class BasiliskSatellite:
         self._rw_motor_torque.vehControlInMsg.subscribeTo(
             self._mrp_control.cmdTorqueOutMsg,
         )
-        self._rw_motor_torque.rwParamsInMsg.subscribeTo(rw_params_message)
+        self._rw_motor_torque.rwParamsInMsg.subscribeTo(self._rw_params_message)
         self._rw_state_effector.rwMotorCmdInMsg.subscribeTo(
             self._rw_motor_torque.rwMotorTorqueOutMsg,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
 ]
-dynamic = [
-    'dependencies',
+dependencies = [
+    'bsk>=2.9.0',
 ]
 
 [project.license]

--- a/setup.sh
+++ b/setup.sh
@@ -17,9 +17,5 @@ pipenv run pip install \
     wheel \
     gymnasium \
     "stable-baselines3[extra]" \
-    pymap3d
-
-cd third_party/basilisk
-sudo apt install swig
-# git checkout c3624e0
-# CMAKE_TLS_VERIFY=0 pipenv run python conanfile.py
+    pymap3d \
+    "bsk>=2.9.0"


### PR DESCRIPTION
1. **GC segfault**: Store rw_params_message as an instance variable to prevent garbage collection. Without this fix, some (depending on bsk version, OS, Python, etc.) may experience segmentation faults due to premature GC of the message object.

2. **Dependency management**: Replace the third_party/basilisk git submodule (<v2.5.13) with the PyPI bsk package (>=v2.9.0). This simplifies installation and leverages bug fixes and improvements in newer Basilisk releases.

The bsk package (v2.9.0) provides the same Basilisk API with improved numerical stability and several known bug fixes.